### PR TITLE
Changed startLiveReplication for PouchDB 5.X

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ var pouchMirror = module.exports = function(dbname, remoteURL, options) {
           back_off_function: function(delay){
             if (delay === 0){
               delay = options.initialTimeout;
+              
+              return delay;
             }
             delay *= options.backoff;
             if (delay > options.maxTimeout) {

--- a/index.js
+++ b/index.js
@@ -90,23 +90,24 @@ var pouchMirror = module.exports = function(dbname, remoteURL, options) {
 
 pouchMirror.prototype.createIndex = function (obj) {
   return this.localDB.createIndex(obj);
-}
+};
 
 pouchMirror.prototype.destroy = function (obj) {
+  this.cancelSync();
   return this.localDB.destroy(obj);
-}
+};
 
 pouchMirror.prototype.find = function (obj) {
   return this.localDB.find(obj);
-}
+};
 
 pouchMirror.prototype.getIndexes = function () {
   return this.localDB.getIndexes();
-}
+};
 
 pouchMirror.prototype.deleteIndex = function (obj) {
   return this.localDB.deleteIndex(obj);
-}
+};
 
 pouchMirror.prototype.get = function () {
   var args = processArgs(arguments);


### PR DESCRIPTION
1. Removed deprecated `uptodate` event.
2. Added PouchDB 5.X compatible `paused`, `denied` and `active` events support.
3. Replaced custom retry logic with PouchDB `retry` and `back_off_function` based retry.
4. Fixed EventEmitter leak by removing `startLiveReplication` call in fatal `error` event. The existing code would keep on adding multiple `on` event handlers to the same replication object. Per the [PouchDB documentation](https://pouchdb.com/api.html#replication), `error` event is fatal and non-recoverable in case of continuous replication, so pouch-mirror should not retry in this case.
5. Added `destroy` API, only deletes localDB.
