### PR TITLE
Added the concept of strategies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .idea/
+.vscode/
 node_modules/
 npm-debug.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+            "stopOnEntry": false,
+            "args": ["test-node"],
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": null,
+            "runtimeExecutable": null,
+            "runtimeArgs": [
+                "--nolazy"
+            ],
+            "env": {
+                "NODE_ENV": "development"
+            },
+            "externalConsole": false,
+            "sourceMaps": false,
+            "outDir": null
+        },
+        {
+            "name": "Attach",
+            "type": "node",
+            "request": "attach",
+            "port": 5858,
+            "address": "localhost",
+            "restart": false,
+            "sourceMaps": false,
+            "outDir": null,
+            "localRoot": "${workspaceRoot}",
+            "remoteRoot": null
+        }
+    ]
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,8 @@
 'use strict';
 
-var Listener = require('./listener');
-var Backoff = require('./backoff');
+var getStrategy = require('./strategy'), 
 
-var PouchMirror = module.exports = function (localDB, remote) {
+PouchMirror = module.exports = function (localDB, remote, strategy) {
   // self and localDB are the same object, but for clarity I will use localDB only in context of db operations
   var self = this;
   if(typeof localDB !== 'object' || !localDB.constructor) {
@@ -24,9 +23,7 @@ var PouchMirror = module.exports = function (localDB, remote) {
   // Clone all the functions from the localDB into the PouchMirror instance
   function cloneLocalDB() {
     function passThroughFn(name) {
-      self[name] = function() {
-        return localDB[name].apply(localDB, arguments);
-      };
+      self[name] = localDB[name].bind(localDB);
     }
     for(var prop in localDB) {
       if(prop.charAt(0) !== '_' && typeof localDB[prop] === 'function' && !self[prop]) {
@@ -36,240 +33,88 @@ var PouchMirror = module.exports = function (localDB, remote) {
   }
 
   cloneLocalDB();
-  self._initState();
-
-};
-
-PouchMirror.prototype._initState = function() {
-  var self = this;
-  // remoteDB is the source of truth until initial sync is complete
-  self._readDB = self._remoteDB;
-  self._remoteSynced = false;
-  self._active = false;
+  
+  self._strategy = getStrategy(self, strategy);
 };
 
 PouchMirror.prototype.start = function (options) {
   var self = this;
-  if(!options) options = {};
-  options.live = true;
-  if(options.retry && typeof options.back_off_function !== 'function') {
-    var backoff = new Backoff(options.maxTimeout);
-    options.back_off_function = backoff;
-    // Export this for testing
-    self._defaultBackoff = backoff;
-  }
-  if(self._active) throw new Error('[PouchMirror] Error: replication already active');
-  self._active = true;
-  // Start buffering changes as they come in
-  self._listener = new Listener(self._localDB);
-  var replicator = self._localDB.replicate.from(self._remoteDB, options)
-    .on('paused', function (err) {
-      if (err) return;
-      if (!self._remoteSynced) {
-        self._remoteSynced = true;
-        self._readDB = self._localDB;
-        replicator.emit('up-to-date', {db: self._localDB._db_name});
-      }
-    })
-    .on('error', function (err) {
-      self._listener.cancel();
-      self._initState();
-      console.error('[PouchMirror] Fatal replication error', err);
-    });
-  replicator._superCancel = replicator.cancel;
-  replicator.cancel = function() {
-    self._listener.cancel();
-    replicator._superCancel();
-    self._initState();
-  };
-  self._replicator = replicator;
-  return replicator;
+  return self._strategy.start(options);
 };
 
 PouchMirror.prototype.pause = function() {
   var self = this;
-  self._replicator.cancel();
+  self._strategy.pause();
 };
 
 PouchMirror.prototype.get = function () {
   var self = this;
-  return self._readDB.get.apply(self._readDB, arguments);
+  return self._strategy.get.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.allDocs = function () {
   var self = this;
-  return self._readDB.allDocs.apply(self._readDB, arguments);
+  return self._strategy.allDocs.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.bulkGet = function () {
   var self = this;
-  return self._readDB.bulkGet.apply(self._readDB, arguments);
+  return self._strategy.bulkGet.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.put = function () {
   var self = this;
-  var argObj = processArgs(arguments);
-  var output;
-  var promise = self._remoteDB.put.apply(self._remoteDB, argObj.args)
-    .then(function (response) {
-      output = response;
-      if(!self._active) return Promise.resolve();
-      return self._listener.waitForChange(response.rev);
-    })
-    .then(function () {
-      return Promise.resolve(output);
-    });
-  if (argObj.cb) callbackify(promise, argObj.cb);
-  return promise;
+  return self._strategy.put.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.post = function () {
   var self = this;
-  var argObj = processArgs(arguments);
-  var output;
-  var promise = self._remoteDB.post.apply(self._remoteDB, argObj.args)
-    .then(function (response) {
-      output = response;
-      if(!self._active) return Promise.resolve();
-      return self._listener.waitForChange(response.rev);
-    })
-    .then(function () {
-      return Promise.resolve(output);
-    });
-  if (argObj.cb) callbackify(promise, argObj.cb);
-  return promise;
+  return self._strategy.post.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.bulkDocs = function () {
   var self = this;
-  var argObj = processArgs(arguments);
-  var output;
-  var promise = self._remoteDB.bulkDocs.apply(self._remoteDB, argObj.args)
-    .then(function (results) {
-      output = results;
-      var promises = [];
-      results.forEach(function (row) {
-        if (row.ok === true) {
-          promises.push(self._listener.waitForChange(row.rev));
-        }
-      });
-      if(!self._active) return Promise.resolve();
-      return Promise.all(promises);
-    })
-    .then(function () {
-      return Promise.resolve(output);
-    });
-  if (argObj.cb) callbackify(promise, argObj.cb);
-  return promise;
+  return self._strategy.bulkDocs.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.remove = function () {
   var self = this;
-  var argObj = processArgs(arguments);
-  var output;
-  var promise = self._remoteDB.remove.apply(self._remoteDB, argObj.args)
-    .then(function (result) {
-      output = result;
-      if(!self._active) return Promise.resolve();
-      return self._listener.waitForChange(result.rev);
-    })
-    .then(function () {
-      return Promise.resolve(output);
-    });
-  if (argObj.cb) callbackify(promise, argObj.cb);
-  return promise;
+  return self._strategy.remove.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.putAttachment = function () {
   var self = this;
-  var argObj = processArgs(arguments);
-  var output;
-  var promise = self._remoteDB.putAttachment.apply(self._remoteDB, argObj.args)
-    .then(function (response) {
-      output = response;
-      if(!self._active) return Promise.resolve();
-      return self._listener.waitForChange(response.rev);
-    })
-    .then(function () {
-      return Promise.resolve(output);
-    });
-  if (argObj.cb) callbackify(promise, argObj.cb);
-  return promise;
+  return self._strategy.putAttachment.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.getAttachment = function () {
   var self = this;
-  return self._readDB.getAttachment.apply(self._readDB, arguments);
+  return self._strategy.getAttachment.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.removeAttachment = function () {
   var self = this;
-  var argObj = processArgs(arguments);
-  var output;
-  var promise = self._remoteDB.removeAttachment.apply(self._remoteDB, argObj.args)
-    .then(function (response) {
-      output = response;
-      if(!self._active) return Promise.resolve();
-      return self._listener.waitForChange(response.rev);
-    })
-    .then(function () {
-      return Promise.resolve(output);
-    });
-  if (argObj.cb) callbackify(promise, argObj.cb);
-  return promise;
+  return self._strategy.removeAttachment.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.query = function () {
   var self = this;
-  return self._readDB.query.apply(self._readDB, arguments);
+  return self._strategy.query.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.info = function () {
   var self = this;
-  var argObj = processArgs(arguments);
-  var theinfo = {};
-  var promise = Promise.all([
-      self._remoteDB.info.apply(self._remoteDB, argObj.args),
-      self._localDB.info.apply(self._localDB, argObj.args)
-    ])
-    .then(function (results) {
-      theinfo.remote = results[0];
-      theinfo.local = results[1];
-      return Promise.resolve(theinfo);
-    });
-  if (argObj.cb) callbackify(promise, argObj.cb);
-  return promise;
+  return self._strategy.info.apply(self._strategy, arguments);
 };
 
 PouchMirror.prototype.replicate = {
   to: function() {
-    this._localDB.replicate.to.apply(this._localDB, arguments);
+    this._strategy.replicate.to.apply(self._strategy, arguments);
   },
   from: function() {
-    this._localDB.replicate.from.apply(this._localDB, arguments);
+    this._strategy.replicate.from.apply(self._strategy, arguments);
   }
 };
-
-// Creates an object that separates the callback from the rest of the arguments
-function processArgs (args) {
-  args = Array.prototype.slice.call(args);
-  if (args.length && typeof args[args.length - 1] === 'function') {
-    var callback = args.pop();
-    return { args: args, cb: callback };
-  } else {
-    return { args: args, cb: null };
-  }
-}
-
-function callbackify(promise, cb) {
-  promise.then(function(result) {
-    cb(null, result);
-    return Promise.resolve(result);
-  }, function(err) {
-    cb(err, null);
-    return Promise.reject(err);
-  });
-}
 
 if(typeof window === 'object') {
   window.PouchMirror = PouchMirror;

--- a/lib/localfirst.js
+++ b/lib/localfirst.js
@@ -1,0 +1,338 @@
+'use strict';
+
+var Backoff = require('./backoff'),
+Listener = require('./listener'), 
+utils = require('./utils'), 
+processArgs = utils.processArgs,
+callbackify = utils.callbackify,
+
+LocalFirst = function (pouchMirror){
+    var self = this;
+    self.pouchMirror = pouchMirror;
+    self._localDB = pouchMirror._localDB;
+    self._remoteDB = pouchMirror._remoteDB;
+    self._initState();
+};
+
+LocalFirst.prototype._initState = function(failOver) {
+  var self = this;
+  // remoteDB is the source of truth until initial sync is complete
+  if (!failOver){
+    self._writeDB = self._readDB = self._remoteDB;
+  }
+  else {
+    // Sync failed fatally, failover to localDB
+    self._writeDB = self._readDB = self._localDB;
+  }
+  self._remoteSynced = false;
+  self._active = false;
+};
+
+LocalFirst.prototype._destroyIfPending = function(){
+    var self = this;
+    if (typeof self._resolvePendingDestroy == 'function'){
+      self._resolvePendingDestroy();
+      self._resolvePendingDestroy = null;
+    }
+};
+
+LocalFirst.prototype.destroy = function(){
+    var self = this,
+        args = arguments;
+    // If delta sync is scheduled, wait for it to complete.
+    if (self._deltaSyncHandle != null){
+        return (new Promise(function (resolve, reject){
+            self._resolvePendingDestroy = resolve;
+        })
+        .then(function(){
+            return self.destroy.apply(self, args);
+        }));
+    }
+    
+    return self._localDB.destroy.apply(self._localDB, args);
+};
+
+LocalFirst.prototype._deltaSync = function(){
+    var self = this;
+    self._listener = new Listener(self._localDB);
+    var replicator = self._localDB.sync(self._remoteDB, 
+    {
+        live: false,
+        back_off_function: self._defaultBackoff
+    })
+    .on('complete', function (info) {
+      if (!self._remoteSynced) {
+        self._remoteSynced = true;
+        self._deltaSyncHandle = null;
+        replicator.emit('up-to-date-delta', {db: self._localDB._db_name});
+        self._destroyIfPending();
+      }
+    })
+    .on('pause', function(err){
+     if (err){
+        console.error('[PouchMirror] Non-fatal delta replication error', err);
+     }
+    })
+    .on('denied', function (err) {
+      console.error('[PouchMirror] Fatal delta replication error', err);
+      self._listener.cancel();
+      self._deltaSyncHandle = null;
+      self._destroyIfPending();
+    })
+    .on('error', function (err) {
+      console.error('[PouchMirror] Fatal replication error', err);
+      self._listener.cancel();
+      self._deltaSyncHandle = null;
+      self._destroyIfPending();
+    });
+  
+  replicator._superCancel = replicator.cancel;
+  replicator.cancel = function() {
+    self._listener.cancel();
+    replicator._superCancel();
+  };
+  self._deltaSyncReplicator = replicator;
+  return replicator;
+};
+
+LocalFirst.prototype._scheduleDeltaSyncOnce = function(debounceIntervalInMs){
+    var self = this;
+    // Clear pending sync on re-entry.
+    if (self._deltaSyncHandle){
+        clearTimeout(self._deltaSyncHandle);
+        self._deltaSyncHandle = null;
+    }
+    
+    self._deltaSyncHandle = setTimeout(self._deltaSync.bind(self), debounceIntervalInMs);
+};
+
+LocalFirst.prototype._monitorLocalChanges = function(debounceIntervalInMs){
+    var self = this;
+    self._localDB.changes({
+        since: 'now',
+        live: true})
+    .on('change', self._scheduleDeltaSyncOnce.bind(self, debounceIntervalInMs))
+    .on('error', function(err){
+        console.error('[PouchMirror] Non-fatal changes feed error', err);
+    });
+};
+
+LocalFirst.prototype.start = function (options) {
+  var self = this;
+  if(!options) options = {};
+  options.live = false;
+  if(options.retry && typeof options.back_off_function !== 'function') {
+    var backoff = new Backoff(options.maxTimeout);
+    options.back_off_function = backoff;
+    // Store this for delta-sync too.
+    self._defaultBackoff = backoff;
+  }
+  if (self._active) throw new Error('[PouchMirror] Error: sync already active');
+  self._active = true;
+  // Start buffering changes as they come in
+  self._listener = new Listener(self._localDB);
+  var replicator = self._localDB.sync(self._remoteDB, options)
+    .on('complete', function (info) {
+        console.log('initial-sync-completed');
+      if (!self._remoteSynced) {
+        self._remoteSynced = true;
+        // Switch local DB as the source of truth.
+        self._writeDB = self._readDB = self._localDB;
+        replicator.emit('up-to-date', {db: self._localDB._db_name});
+        // Start monitoring local changes
+        self._monitorLocalChanges(options.debounceInterval || 1000);
+      }
+    })
+    .on('pause', function(err){
+     if (err){
+        console.error('[PouchMirror] Non-fatal replication error', err);
+     }
+    })
+    .on('denied', function (err) {
+      self._listener.cancel();
+      self._initState(true);
+      console.error('[PouchMirror] Fatal replication error', err);
+    })
+    .on('error', function (err) {
+      self._listener.cancel();
+      self._initState(true);
+      console.error('[PouchMirror] Fatal replication error', err);
+    });
+  replicator._superCancel = replicator.cancel;
+  replicator.cancel = function() {
+    self._listener.cancel();
+    replicator._superCancel();
+    self._initState();
+  };
+  self._syncReplicator = replicator;
+  return replicator;
+};
+
+LocalFirst.prototype.pause = function() {
+  var self = this;
+  self._syncReplicator.cancel();
+  self._deltaSyncReplicator.cancel();
+};
+
+LocalFirst.prototype.get = function () {
+  var self = this;
+  return self._readDB.get.apply(self._readDB, arguments);
+};
+
+LocalFirst.prototype.allDocs = function () {
+  var self = this;
+  return self._readDB.allDocs.apply(self._readDB, arguments);
+};
+
+LocalFirst.prototype.bulkGet = function () {
+  var self = this;
+  return self._readDB.bulkGet.apply(self._readDB, arguments);
+};
+
+LocalFirst.prototype.put = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._writeDB.put.apply(self._writeDB, argObj.args)
+    .then(function (response) {
+      output = response;
+      if(!self._active) return Promise.resolve();
+      return self._listener.waitForChange(response.rev);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+LocalFirst.prototype.post = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  console.log("Writing to remotedDB? " + (self._writeDB == self._remoteDB));
+  console.log("Writing to localDB? " + (self._writeDB == self._localDB));
+  var promise = self._writeDB.post.apply(self._writeDB, argObj.args)
+    .then(function (response) {
+      output = response;
+      if(!self._active) return Promise.resolve();
+      return self._listener.waitForChange(response.rev);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+LocalFirst.prototype.bulkDocs = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._writeDB.bulkDocs.apply(self._writeDB, argObj.args)
+    .then(function (results) {
+      output = results;
+      var promises = [];
+      results.forEach(function (row) {
+        if (row.ok === true) {
+          promises.push(self._listener.waitForChange(row.rev));
+        }
+      });
+      if(!self._active) return Promise.resolve();
+      return Promise.all(promises);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+LocalFirst.prototype.remove = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._writeDB.remove.apply(self._writeDB, argObj.args)
+    .then(function (result) {
+      output = result;
+      if(!self._active) return Promise.resolve();
+      return self._listener.waitForChange(result.rev);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+LocalFirst.prototype.putAttachment = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._writeDB.putAttachment.apply(self._writeDB, argObj.args)
+    .then(function (response) {
+      output = response;
+      if(!self._active) return Promise.resolve();
+      return self._listener.waitForChange(response.rev);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+LocalFirst.prototype.getAttachment = function () {
+  var self = this;
+  return self._readDB.getAttachment.apply(self._readDB, arguments);
+};
+
+LocalFirst.prototype.removeAttachment = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._writeDB.removeAttachment.apply(self._writeDB, argObj.args)
+    .then(function (response) {
+      output = response;
+      if(!self._active) return Promise.resolve();
+      return self._listener.waitForChange(response.rev);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+LocalFirst.prototype.query = function () {
+  var self = this;
+  return self._readDB.query.apply(self._readDB, arguments);
+};
+
+LocalFirst.prototype.info = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var theinfo = {};
+  var promise = Promise.all([
+      self._remoteDB.info.apply(self._remoteDB, argObj.args),
+      self._localDB.info.apply(self._localDB, argObj.args)
+    ])
+    .then(function (results) {
+      theinfo.remote = results[0];
+      theinfo.local = results[1];
+      return Promise.resolve(theinfo);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+LocalFirst.prototype.replicate = {
+  to: function() {
+    this._localDB.replicate.to.apply(this._localDB, arguments);
+  },
+  from: function() {
+    this._localDB.replicate.from.apply(this._localDB, arguments);
+  }
+};
+
+module.exports = LocalFirst;

--- a/lib/remotefirst.js
+++ b/lib/remotefirst.js
@@ -1,0 +1,232 @@
+'use strict';
+
+var Backoff = require('./backoff'),
+Listener = require('./listener'), 
+utils = require('./utils'), 
+processArgs = utils.processArgs,
+callbackify = utils.callbackify,
+
+RemoteFirst = function (pouchMirror){
+    var self = this;
+    self.pouchMirror = pouchMirror;
+    self._localDB = pouchMirror._localDB;
+    self._remoteDB = pouchMirror._remoteDB;
+    self._initState();
+};
+
+RemoteFirst.prototype._initState = function() {
+  var self = this;
+  // remoteDB is the source of truth until initial sync is complete
+  self._readDB = self._remoteDB;
+  self._remoteSynced = false;
+  self._active = false;
+};
+
+RemoteFirst.prototype.destroy = function(){
+    var self = this;
+    return self._localDB.destroy.apply(self._localDB, arguments);
+};
+
+RemoteFirst.prototype.start = function (options) {
+  var self = this;
+  if(!options) options = {};
+  options.live = true;
+  if(options.retry && typeof options.back_off_function !== 'function') {
+    var backoff = new Backoff(options.maxTimeout);
+    options.back_off_function = backoff;
+    // Export this for testing
+    self._defaultBackoff = backoff;
+  }
+  if(self._active) throw new Error('[PouchMirror] Error: replication already active');
+  self._active = true;
+  // Start buffering changes as they come in
+  self._listener = new Listener(self._localDB);
+  var replicator = self._localDB.replicate.from(self._remoteDB, options)
+    .on('paused', function (err) {
+      if (err) return;
+      if (!self._remoteSynced) {
+        self._remoteSynced = true;
+        self._readDB = self._localDB;
+        replicator.emit('up-to-date', {db: self._localDB._db_name});
+      }
+    })
+    .on('error', function (err) {
+      self._listener.cancel();
+      self._initState();
+      console.error('[PouchMirror] Fatal replication error', err);
+    });
+  replicator._superCancel = replicator.cancel;
+  replicator.cancel = function() {
+    self._listener.cancel();
+    replicator._superCancel();
+    self._initState();
+  };
+  self._replicator = replicator;
+  return replicator;
+};
+
+RemoteFirst.prototype.pause = function() {
+  var self = this;
+  self._replicator.cancel();
+};
+
+RemoteFirst.prototype.get = function () {
+  var self = this;
+  return self._readDB.get.apply(self._readDB, arguments);
+};
+
+RemoteFirst.prototype.allDocs = function () {
+  var self = this;
+  return self._readDB.allDocs.apply(self._readDB, arguments);
+};
+
+RemoteFirst.prototype.bulkGet = function () {
+  var self = this;
+  return self._readDB.bulkGet.apply(self._readDB, arguments);
+};
+
+RemoteFirst.prototype.put = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._remoteDB.put.apply(self._remoteDB, argObj.args)
+    .then(function (response) {
+      output = response;
+      if(!self._active) return Promise.resolve();
+      return self._listener.waitForChange(response.rev);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+RemoteFirst.prototype.post = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._remoteDB.post.apply(self._remoteDB, argObj.args)
+    .then(function (response) {
+      output = response;
+      if(!self._active) return Promise.resolve();
+      return self._listener.waitForChange(response.rev);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+RemoteFirst.prototype.bulkDocs = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._remoteDB.bulkDocs.apply(self._remoteDB, argObj.args)
+    .then(function (results) {
+      output = results;
+      var promises = [];
+      results.forEach(function (row) {
+        if (row.ok === true) {
+          promises.push(self._listener.waitForChange(row.rev));
+        }
+      });
+      if(!self._active) return Promise.resolve();
+      return Promise.all(promises);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+RemoteFirst.prototype.remove = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._remoteDB.remove.apply(self._remoteDB, argObj.args)
+    .then(function (result) {
+      output = result;
+      if(!self._active) return Promise.resolve();
+      return self._listener.waitForChange(result.rev);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+RemoteFirst.prototype.putAttachment = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._remoteDB.putAttachment.apply(self._remoteDB, argObj.args)
+    .then(function (response) {
+      output = response;
+      if(!self._active) return Promise.resolve();
+      return self._listener.waitForChange(response.rev);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+RemoteFirst.prototype.getAttachment = function () {
+  var self = this;
+  return self._readDB.getAttachment.apply(self._readDB, arguments);
+};
+
+RemoteFirst.prototype.removeAttachment = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var output;
+  var promise = self._remoteDB.removeAttachment.apply(self._remoteDB, argObj.args)
+    .then(function (response) {
+      output = response;
+      if(!self._active) return Promise.resolve();
+      return self._listener.waitForChange(response.rev);
+    })
+    .then(function () {
+      return Promise.resolve(output);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+RemoteFirst.prototype.query = function () {
+  var self = this;
+  return self._readDB.query.apply(self._readDB, arguments);
+};
+
+RemoteFirst.prototype.info = function () {
+  var self = this;
+  var argObj = processArgs(arguments);
+  var theinfo = {};
+  var promise = Promise.all([
+      self._remoteDB.info.apply(self._remoteDB, argObj.args),
+      self._localDB.info.apply(self._localDB, argObj.args)
+    ])
+    .then(function (results) {
+      theinfo.remote = results[0];
+      theinfo.local = results[1];
+      return Promise.resolve(theinfo);
+    });
+  if (argObj.cb) callbackify(promise, argObj.cb);
+  return promise;
+};
+
+RemoteFirst.prototype.replicate = {
+  to: function() {
+    this._localDB.replicate.to.apply(this._localDB, arguments);
+  },
+  from: function() {
+    this._localDB.replicate.from.apply(this._localDB, arguments);
+  }
+};
+
+module.exports = RemoteFirst;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,0 +1,46 @@
+'use strict'
+var RemoteFirst = require('./remotefirst'),
+LocalFirst = require('./localfirst'),
+// There are two strategies available in Pouch-Mirror -
+// 1. remote-first.
+// This is the default strategy and is backward-compatible with the previous
+// versions of Pouch-Mirror (upto 0.2.0). In this mode, Pouch-Mirror keeps
+// the remote DB as the source of truth for all writes (always) and for all
+// reads (till the local DB is populated). It's guaranteed that there will be
+// no write conflicts in this mode.
+// 
+// 2. local-first.
+// This is a new strategy introduced in 0.3.0, to cater to local interactions
+// heavy scenarios. Although the remote-first strategy guarantees 
+// no-write-conflicts, it cannot be used when there are lots of local 
+// interactions, or when the remote DB is unavailable. In these conditions,
+// you can use this strategy to ensure the data needs are fulfilled by the
+// local DB with the changes eventually sync'd with the remote DB.
+// In this strategy, there is an initial two-way sync with the remote.
+// During this initial sync, the remote is the source of truth. Afterwards,
+// the local DB becomes the source-of-truth for all read/writes. When a write
+// is detected locally, a one-time two-way remote sync is debounced with a
+// configurable delay timer. This allows quick local turnaround without waiting
+// for remote sync to complete when there are frequent back-to-back writes.
+
+// Here's a quick comparison chart -
+
+// |   Strategy   |    Stage     | SOT Read | SOT Write | Works Offline | Conflicts Occurrence? |
+// |--------------|--------------|----------|-----------|---------------|-----------------------|
+// | remote-first | initial sync | remote   | remote    | No            | No-conflicts          |
+// | remote-first | delta sync   | local    | remote    | No            | No-conflicts          |
+// | local-first  | initial sync | remote   | remote    | Yes           | No-conflicts          |
+// | local-first  | delta sync   | local    | local     | Yes           | Possible              |
+// |--------------|--------------|----------|-----------|---------------|-----------------------|
+
+getStrategy = function(pouchMirror, strategy){
+    if (!strategy || strategy == 'remote-first'){
+        return new RemoteFirst(pouchMirror);
+    }
+    
+    if (strategy == 'local-first'){
+        return new LocalFirst(pouchMirror);
+    }
+}
+
+module.exports = getStrategy;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,3 +33,24 @@ exports.timeout = function(promise, time) {
     })
   ]);
 };
+
+// Creates an object that separates the callback from the rest of the arguments
+exports.processArgs = function  (args) {
+  args = Array.prototype.slice.call(args);
+  if (args.length && typeof args[args.length - 1] === 'function') {
+    var callback = args.pop();
+    return { args: args, cb: callback };
+  } else {
+    return { args: args, cb: null };
+  }
+}
+
+exports.callbackify = function (promise, cb) {
+  promise.then(function(result) {
+    cb(null, result);
+    return Promise.resolve(result);
+  }, function(err) {
+    cb(err, null);
+    return Promise.reject(err);
+  });
+}

--- a/test/pouch-mirror.spec.js
+++ b/test/pouch-mirror.spec.js
@@ -17,204 +17,413 @@ if(typeof window !== 'object') {
 var remoteURL = 'http://localhost:5984/pouchtest';
 var dbname = 'pouchtest';
 
-describe('PouchMirror', function () {
+describe (('PouchMirror'), function(){
+  
+  describe('Remote First', function () {
 
-  var localDB, remoteDB, mirror, replicator, emitterPromise, previous;
+    var localDB, remoteDB, mirror, replicator, emitterPromise, previous;
 
-  before(function() {
-    // Used to make sure the previous test has completed before starting the next one
-    previous = Promise.resolve();
-    localDB = new PouchDB(dbname, dbOptions);
-    remoteDB = new PouchDB(remoteURL);
-    mirror = new PouchMirror(localDB, remoteDB);
-    replicator = mirror.start({retry: true});
+    before(function() {
+      // Used to make sure the previous test has completed before starting the next one
+      previous = Promise.resolve();
+      localDB = new PouchDB(dbname, dbOptions);
+      remoteDB = new PouchDB(remoteURL);
+      mirror = new PouchMirror(localDB, remoteDB);
+      replicator = mirror.start({retry: true});
 
-    // To test the up-to-date event
-    emitterPromise = new Promise(function(resolve) {
-      replicator.on('up-to-date', function() {
-        resolve();
+      // To test the up-to-date event
+      emitterPromise = new Promise(function(resolve) {
+        replicator.on('up-to-date', function() {
+          resolve();
+        });
       });
     });
-  });
 
-  after(function() {
-    return Promise.all([mirror._remoteDB.destroy(), mirror._localDB.destroy()]);
-  });
-
-  describe('info()', function () {
-
-    it('should return info from local and remote', function () {
-      return previous
-        .then(function() {
-          return mirror.info();
-        })
-        .then(function (results) {
-          expect(results.remote.db_name).to.equal(dbname);
-          expect(results.local.db_name).to.equal(dbname);
-        })
-        .catch(function(err) {
-          return Promise.reject(err);
-        });
+    after(function() {
+      return Promise.all([mirror._remoteDB.destroy(), mirror._localDB.destroy()]);
     });
 
-  });
+    describe('info()', function () {
 
-  describe('post() and remove()', function () {
-    var newID;
-    var newRev;
-    var newDoc;
+      it('should return info from local and remote', function () {
+        return previous
+          .then(function() {
+            return mirror.info();
+          })
+          .then(function (results) {
+            expect(results.remote.db_name).to.equal(dbname);
+            expect(results.local.db_name).to.equal(dbname);
+          })
+          .catch(function(err) {
+            return Promise.reject(err);
+          });
+      });
 
-    it('should add a new document to both local and remote', function () {
-      return previous
-        .then(function() {
-          return mirror.post({title: 'testdoc1'});
-        })
-        .then(function (response) {
-          newID = response.id;
-          newRev = response.rev;
-          return localDB.get(newID);
-        })
-        .then(function (local) {
-          newDoc = local;
-          expect(local.title).to.equal('testdoc1');
-          return mirror._remoteDB.get(newID);
-        })
-        .then(function (remote) {
-          expect(newDoc._rev).to.equal(remote._rev);
-          expect(remote.title).to.equal('testdoc1');
-        })
-        .catch(function(err) {
-          return Promise.reject(err);
-        });
     });
 
-    it('should remove the document we just added', function () {
-      return previous
-        .then(function() {
-          return mirror.remove(newID, newRev);
-        })
-        .then(function () {
-          return mirror._localDB.get(newID);
-        })
-        .catch(function (err) {
-          expect(err.reason || err.message).to.equal('deleted');
-        });
+    describe('post() and remove()', function () {
+      var newID;
+      var newRev;
+      var newDoc;
+
+      it('should add a new document to both local and remote', function () {
+        return previous
+          .then(function() {
+            return mirror.post({title: 'testdoc1'});
+          })
+          .then(function (response) {
+            newID = response.id;
+            newRev = response.rev;
+            return localDB.get(newID);
+          })
+          .then(function (local) {
+            newDoc = local;
+            expect(local.title).to.equal('testdoc1');
+            return mirror._remoteDB.get(newID);
+          })
+          .then(function (remote) {
+            expect(newDoc._rev).to.equal(remote._rev);
+            expect(remote.title).to.equal('testdoc1');
+          })
+          .catch(function(err) {
+            return Promise.reject(err);
+          });
+      });
+
+      it('should remove the document we just added', function () {
+        return previous
+          .then(function() {
+            return mirror.remove(newID, newRev);
+          })
+          .then(function () {
+            return mirror._localDB.get(newID);
+          })
+          .catch(function (err) {
+            expect(err.reason || err.message).to.equal('deleted');
+          });
+      });
+
     });
 
-  });
+    describe('bulkDocs', function () {
+      var testDocs = [
+        {_id: 'testDoc2', title: 'hello2'},
+        {title: 'hello3'}
+      ];
+      it('should write two documents across remote and local', function () {
+        return previous
+          .then(function() {
+            return mirror.bulkDocs(testDocs);
+          })
+          .then(function (results) {
+            expect(results[0].id).to.equal('testDoc2');
+          });
+      });
 
-  describe('bulkDocs', function () {
-    var testDocs = [
-      {_id: 'testDoc2', title: 'hello2'},
-      {title: 'hello3'}
-    ];
-    it('should write two documents across remote and local', function () {
-      return previous
-        .then(function() {
-          return mirror.bulkDocs(testDocs);
-        })
-        .then(function (results) {
-          expect(results[0].id).to.equal('testDoc2');
-        });
     });
 
-  });
+    describe('attachments', function () {
+      
+      var sampledoc = {
+        _id: 'sampledoc'
+      };
 
-  describe('attachments', function () {
-    
-    var sampledoc = {
-      _id: 'sampledoc'
-    };
-
-    var attachment =
-      'TGVnZW5kYXJ5IGhlYXJ0cywgdGVhciB1cyBhbGwgYXBhcnQKTWFrZS' +
-      'BvdXIgZW1vdGlvbnMgYmxlZWQsIGNyeWluZyBvdXQgaW4gbmVlZA==';
-    
-    it('should save, get, and remove an attachment', function () {
-      var rev;
-      return previous
-        .then(function() {
-          return mirror.put(sampledoc);
-        })
-        .then(function (result) {
-          return mirror.putAttachment('sampledoc', 'text', result.rev, attachment, 'text/plain');
-        })
-        .then(function (result) {
-          rev = result.rev;
-          expect(result.ok).to.equal(true);
-          return mirror.getAttachment('sampledoc', 'text');
-        })
-        .then(function (result) {
-          expect(result.size || result.length).to.equal(79);
-          return mirror.removeAttachment('sampledoc', 'text', rev);
-        })
-        .then(function (response) {
-          expect(response.ok).to.equal(true);
-        });
-    });
-    
-  });
-
-  describe('Backoff', function() {
-
-    it('should start off less than two seconds and never exceed 10 minutes', function() {
-      var backoff = mirror._defaultBackoff;
-      var limit = 600000;
-      var delay = 0;
-      var values = [];
-      for(var i=0; i<100; i++) {
-        delay = backoff(delay);
-        values.push(delay);
-      }
-      var max = Math.max.apply(null, values);
-      expect(values[0]).to.be.at.most(2000);
-      expect(max).to.be.at.most(limit);
+      var attachment =
+        'TGVnZW5kYXJ5IGhlYXJ0cywgdGVhciB1cyBhbGwgYXBhcnQKTWFrZS' +
+        'BvdXIgZW1vdGlvbnMgYmxlZWQsIGNyeWluZyBvdXQgaW4gbmVlZA==';
+      
+      it('should save, get, and remove an attachment', function () {
+        var rev;
+        return previous
+          .then(function() {
+            return mirror.put(sampledoc);
+          })
+          .then(function (result) {
+            return mirror.putAttachment('sampledoc', 'text', result.rev, attachment, 'text/plain');
+          })
+          .then(function (result) {
+            rev = result.rev;
+            expect(result.ok).to.equal(true);
+            return mirror.getAttachment('sampledoc', 'text');
+          })
+          .then(function (result) {
+            expect(result.size || result.length).to.equal(79);
+            return mirror.removeAttachment('sampledoc', 'text', rev);
+          })
+          .then(function (response) {
+            expect(response.ok).to.equal(true);
+          });
+      });
+      
     });
 
-  });
+    describe('Backoff', function() {
 
-  describe('PouchMirror API', function() {
+      it('should start off less than two seconds and never exceed 10 minutes', function() {
+        var backoff = mirror._strategy._defaultBackoff;
+        var limit = 600000;
+        var delay = 0;
+        var values = [];
+        for(var i=0; i<100; i++) {
+          delay = backoff(delay);
+          values.push(delay);
+        }
+        var max = Math.max.apply(null, values);
+        expect(values[0]).to.be.at.most(2000);
+        expect(max).to.be.at.most(limit);
+      });
 
-    it('should pass through functions from the localDB object', function() {
-      expect(mirror.type()).to.equal('leveldb');
     });
 
-    it('should work with callbacks', function() {
-      return previous
-        .then(function() {
-          return new Promise(function(resolve) {
-            mirror.put({_id: 'callback_test'}, function(err, result) {
-              expect(result.id).to.equal('callback_test');
-              mirror.get('callback_test', function(err, doc) {
-                expect(doc._id).to.equal('callback_test');
-                resolve(true);
+    describe('PouchMirror API', function() {
+
+      it('should pass through functions from the localDB object', function() {
+        expect(mirror.type()).to.equal('leveldb');
+      });
+
+      it('should work with callbacks', function() {
+        return previous
+          .then(function() {
+            return new Promise(function(resolve) {
+              mirror.put({_id: 'callback_test'}, function(err, result) {
+                expect(result.id).to.equal('callback_test');
+                mirror.get('callback_test', function(err, doc) {
+                  expect(doc._id).to.equal('callback_test');
+                  resolve(true);
+                });
               });
             });
           });
-        });
-    });
+      });
 
-    it('should have emitted an up-to-date event', function() {
-      return previous
-        .then(function() {
-          return emitterPromise;
-        })
-        .then(function() {
-          expect(mirror._remoteSynced).to.equal(true);
-          expect(mirror._readDB).to.equal(localDB);
-        });
-    });
+      it('should have emitted an up-to-date event', function() {
+        return previous
+          .then(function() {
+            return emitterPromise;
+          })
+          .then(function() {
+            expect(mirror._strategy._remoteSynced).to.equal(true);
+            expect(mirror._strategy._readDB).to.equal(localDB);
+          });
+      });
 
-    it('should pause and restart replication without error', function() {
-      expect(mirror._active).to.equal(true);
-      mirror.pause();
-      expect(mirror._active).to.equal(false);
-      expect(mirror._remoteSynced).to.equal(false);
-      expect(mirror._readDB).to.equal(remoteDB);
-      mirror.start();
-      expect(mirror._active).to.equal(true);
+      it('should pause and restart replication without error', function() {
+        expect(mirror._strategy._active).to.equal(true);
+        mirror.pause();
+        expect(mirror._strategy._active).to.equal(false);
+        expect(mirror._strategy._remoteSynced).to.equal(false);
+        expect(mirror._strategy._readDB).to.equal(remoteDB);
+        mirror.start();
+        expect(mirror._strategy._active).to.equal(true);
+      });
+
     });
 
   });
+  
+  xdescribe('Local First', function () {
 
+    var localDB, remoteDB, mirror, replicator, emitterPromise, previous;
+
+    before(function() {
+      // Used to make sure the previous test has completed before starting the next one
+      previous = Promise.resolve();
+      localDB = new PouchDB(dbname, dbOptions);
+      remoteDB = new PouchDB(remoteURL);
+      mirror = new PouchMirror(localDB, remoteDB, 'local-first');
+      replicator = mirror.start({retry: true});
+
+      // To test the up-to-date event
+      emitterPromise = new Promise(function(resolve) {
+        replicator.on('up-to-date', function() {
+          resolve();
+        });
+      });
+    });
+
+    after(function() {
+      return Promise.all([mirror._remoteDB.destroy(), mirror._localDB.destroy()]);
+    });
+
+    describe('info()', function () {
+
+      it('should return info from local and remote', function () {
+        return previous
+          .then(function() {
+            return mirror.info();
+          })
+          .then(function (results) {
+            expect(results.remote.db_name).to.equal(dbname);
+            expect(results.local.db_name).to.equal(dbname);
+          })
+          .catch(function(err) {
+            return Promise.reject(err);
+          });
+      });
+
+    });
+
+    describe('post() and remove()', function () {
+      var newID;
+      var newRev;
+      var newDoc;
+
+      it('should add a new document to both local and remote', function () {
+        return previous
+          .then(function() {
+            console.log(1);
+            return mirror.post({title: 'testdoc1'});
+          })
+          .then(function (response) {
+            newID = response.id;
+            newRev = response.rev;
+            console.log(2);
+            return localDB.get(newID);
+          })
+          .then(function (local) {
+            newDoc = local;
+            console.log(3);
+            expect(local.title).to.equal('testdoc1');
+            return mirror._remoteDB.get(newID);
+          })
+          .then(function (remote) {
+            console.log(4);
+            expect(newDoc._rev).to.equal(remote._rev);
+            expect(remote.title).to.equal('testdoc1');
+          })
+          .catch(function(err) {
+            return Promise.reject(err);
+          });
+      });
+
+      it('should remove the document we just added', function () {
+        return previous
+          .then(function() {
+            return mirror.remove(newID, newRev);
+          })
+          .then(function () {
+            return mirror._localDB.get(newID);
+          })
+          .catch(function (err) {
+            expect(err.reason || err.message).to.equal('deleted');
+          });
+      });
+
+    });
+
+    describe('bulkDocs', function () {
+      var testDocs = [
+        {_id: 'testDoc2', title: 'hello2'},
+        {title: 'hello3'}
+      ];
+      it('should write two documents across remote and local', function () {
+        return previous
+          .then(function() {
+            return mirror.bulkDocs(testDocs);
+          })
+          .then(function (results) {
+            expect(results[0].id).to.equal('testDoc2');
+          });
+      });
+
+    });
+
+    describe('attachments', function () {
+      
+      var sampledoc = {
+        _id: 'sampledoc'
+      };
+
+      var attachment =
+        'TGVnZW5kYXJ5IGhlYXJ0cywgdGVhciB1cyBhbGwgYXBhcnQKTWFrZS' +
+        'BvdXIgZW1vdGlvbnMgYmxlZWQsIGNyeWluZyBvdXQgaW4gbmVlZA==';
+      
+      it('should save, get, and remove an attachment', function () {
+        var rev;
+        return previous
+          .then(function() {
+            return mirror.put(sampledoc);
+          })
+          .then(function (result) {
+            return mirror.putAttachment('sampledoc', 'text', result.rev, attachment, 'text/plain');
+          })
+          .then(function (result) {
+            rev = result.rev;
+            expect(result.ok).to.equal(true);
+            return mirror.getAttachment('sampledoc', 'text');
+          })
+          .then(function (result) {
+            expect(result.size || result.length).to.equal(79);
+            return mirror.removeAttachment('sampledoc', 'text', rev);
+          })
+          .then(function (response) {
+            expect(response.ok).to.equal(true);
+          });
+      });
+      
+    });
+
+    describe('Backoff', function() {
+
+      it('should start off less than two seconds and never exceed 10 minutes', function() {
+        var backoff = mirror._strategy._defaultBackoff;
+        var limit = 600000;
+        var delay = 0;
+        var values = [];
+        for(var i=0; i<100; i++) {
+          delay = backoff(delay);
+          values.push(delay);
+        }
+        var max = Math.max.apply(null, values);
+        expect(values[0]).to.be.at.most(2000);
+        expect(max).to.be.at.most(limit);
+      });
+
+    });
+
+    describe('PouchMirror API', function() {
+
+      it('should pass through functions from the localDB object', function() {
+        expect(mirror.type()).to.equal('leveldb');
+      });
+
+      it('should work with callbacks', function() {
+        return previous
+          .then(function() {
+            return new Promise(function(resolve) {
+              mirror.put({_id: 'callback_test'}, function(err, result) {
+                expect(result.id).to.equal('callback_test');
+                mirror.get('callback_test', function(err, doc) {
+                  expect(doc._id).to.equal('callback_test');
+                  resolve(true);
+                });
+              });
+            });
+          });
+      });
+
+      it('should have emitted an up-to-date event', function() {
+        return previous
+          .then(function() {
+            return emitterPromise;
+          })
+          .then(function() {
+            expect(mirror._strategy._remoteSynced).to.equal(true);
+            expect(mirror._strategy._readDB).to.equal(localDB);
+          });
+      });
+
+      it('should pause and restart replication without error', function() {
+        expect(mirror._strategy._active).to.equal(true);
+        mirror.pause();
+        expect(mirror._strategy._active).to.equal(false);
+        expect(mirror._strategy._remoteSynced).to.equal(false);
+        expect(mirror._strategy._readDB).to.equal(remoteDB);
+        mirror.start();
+        expect(mirror._strategy._active).to.equal(true);
+      });
+
+    });
+
+  });
 });


### PR DESCRIPTION
The 0.2.0 version behavior is now clubbed under `remote-first` strategy, and a new `local-first` strategy has been added. For backward compatibility, the code defaults to `remote-first` when a strategy has not been specified in the constructor.

Pending - 
Local-first strategy test specs.
