### PR TITLE
remove unneeded slave term

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ PouchMirror
 
 **Version 0.2.0 has a NEW API, see usage below.**
 
-PouchMirror helps you create a local slave mirror of any CouchDB database for lightning-fast reads and secure writes. It now works in both NodeJS and the browser!
+PouchMirror helps you create a local mirror of any CouchDB database for lightning-fast reads and secure writes. It now works in both NodeJS and the browser!
 
 Accessing a remote CouchDB instance can be slow. PouchDB is an incredible tool that allows you to create local 
 instances of your databases in any Javascript environment and keep them in sync with your server. The problem is that 


### PR DESCRIPTION
hey I think you can remove the "slave" to describe `pouch-mirror` altogether. Or if you want to keep a term expressing that it’s replicating from a primary database, user "replica" instead? see also https://www.drupal.org/node/2275877, lots of other projects try to remove master/slave and other terms with negative annotation from their project to make your community more inclusive. 

Thanks for your consideration. Let me know if you have questions, happy to provide more resources on that topic